### PR TITLE
Fix archiving and deleting images

### DIFF
--- a/core/components/mediamanager/lexicon/de/default.inc.php
+++ b/core/components/mediamanager/lexicon/de/default.inc.php
@@ -125,6 +125,7 @@ $_lang['mediamanager.files.error.file_not_found'] = 'Datei nicht gefunden.';
 $_lang['mediamanager.files.error.image_not_saved'] = 'Das Bild konnte nicht gespeichert werden.';
 $_lang['mediamanager.files.error.file_copy'] = 'Die Datei `[[+file]]` konnte nicht kopiert werden.';
 $_lang['mediamanager.files.error.filetoobig'] = 'Die ausgewählte Datei ist zu groß.';
+$_lang['mediamanager.files.error.delete_dir'] = 'Verzeichnis `[[+dir]]` konnte nicht gelöscht werden';
 $_lang['mediamanager.files.success.file_upload'] = 'Die Datei `[[+file]]` wurde hochgeladen.';
 $_lang['mediamanager.files.success.files_moved'] = 'Die Datei wurde erfolgreich verschoben.';
 $_lang['mediamanager.files.success.image_saved'] = 'Bild gespeichert.';

--- a/core/components/mediamanager/lexicon/de/default.inc.php
+++ b/core/components/mediamanager/lexicon/de/default.inc.php
@@ -120,6 +120,7 @@ $_lang['mediamanager.files.error.file_upload'] = 'Die Datei `[[+file]]` konnte n
 $_lang['mediamanager.files.error.file_save'] = 'Die Datei `[[+file]]` konnte nicht in die Datenbank eingetragen werden.';
 $_lang['mediamanager.files.error.file_linked'] = 'Die Datei `[[+file]]` wird noch in einer Ressource genutzt.';
 $_lang['mediamanager.files.error.file_archive'] = 'Die Datei mit der ID `[[+id]]` konnte nicht archiviert werden.';
+$_lang['mediamanager.files.error.file_unarchive'] = 'Die Datei mit der ID `[[+id]]` konnte nicht wiederhergestellt werden.';
 $_lang['mediamanager.files.error.file_not_found'] = 'Datei nicht gefunden.';
 $_lang['mediamanager.files.error.image_not_saved'] = 'Das Bild konnte nicht gespeichert werden.';
 $_lang['mediamanager.files.error.file_copy'] = 'Die Datei `[[+file]]` konnte nicht kopiert werden.';

--- a/core/components/mediamanager/lexicon/en/default.inc.php
+++ b/core/components/mediamanager/lexicon/en/default.inc.php
@@ -121,6 +121,7 @@ $_lang['mediamanager.files.error.file_upload'] = 'File `[[+file]]` could not be 
 $_lang['mediamanager.files.error.file_save'] = 'File `[[+file]]` not added to database.';
 $_lang['mediamanager.files.error.file_linked'] = 'File `[[+file]]` is used in resource.';
 $_lang['mediamanager.files.error.file_archive'] = 'Could not archive file with id `[[+id]]`.';
+$_lang['mediamanager.files.error.file_unarchive'] = 'Could not unarchive file with id `[[+id]]`.';
 $_lang['mediamanager.files.error.file_not_found'] = 'File not found.';
 $_lang['mediamanager.files.error.image_not_saved'] = 'Image not saved.';
 $_lang['mediamanager.files.error.file_copy'] = 'Could not copy file `[[+file]]` to own source.';

--- a/core/components/mediamanager/lexicon/en/default.inc.php
+++ b/core/components/mediamanager/lexicon/en/default.inc.php
@@ -126,6 +126,7 @@ $_lang['mediamanager.files.error.file_not_found'] = 'File not found.';
 $_lang['mediamanager.files.error.image_not_saved'] = 'Image not saved.';
 $_lang['mediamanager.files.error.file_copy'] = 'Could not copy file `[[+file]]` to own source.';
 $_lang['mediamanager.files.error.filetoobig'] = 'The file you selected is too big.';
+$_lang['mediamanager.files.error.delete_dir'] = 'Could not delete directory `[[+dir]]`';
 $_lang['mediamanager.files.success.file_upload'] = 'File `[[+file]]` uploaded.';
 $_lang['mediamanager.files.success.files_moved'] = 'Successfully moved files.';
 $_lang['mediamanager.files.success.image_saved'] = 'Image saved.';

--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -200,22 +200,8 @@ class MediaManagerFilesHelper
         ];
 
         $data                     = $this->getFile($fileId);
-        $file                     = $data['file']->toArray();
-        $source                   = $this->mediaManager->sources->getSource($file['media_sources_id']);
-
-        $file['file_size']        = $this->formatFileSize($file['file_size']);
+        $file                     = $this->fileToArray($data['file']);
         $file['uploaded_by_name'] = ($data['user'] !== null ? $data['user']->get('fullname') : $this->mediaManager->modx->lexicon('mediamanager.files.file_unknown_user'));
-        $file['is_archived']      = (int) $file['is_archived'];
-        $file['file_path']        = $file['path'];
-        $file['path']             = $this->fileUrl($file, $source);
-        $file['base_path']        = $source['basePath'];
-
-        if ($source['basePathRelative'] !== false) {
-            $file['base_path'] = $this->addTrailingSlash(MODX_BASE_PATH) .
-                $this->removeSlashes($source['basePath']) .
-                DIRECTORY_SEPARATOR;
-        }
-
         $bodyData['file']         = $file;
         $footerData['file']       = $file;
 
@@ -532,6 +518,42 @@ class MediaManagerFilesHelper
     }
 
     /**
+     * Return array from file row
+     *
+     * @param object $file
+     * @param null|object $source
+     *
+     * @return array
+     */
+    public function fileToArray(MediamanagerFiles $file = null, $source = null)
+    {
+        if ($file === null) {
+            return [];
+        }
+
+        $file = $file->toArray();
+
+        if ($source === null) {
+            $source = $this->mediaManager->sources->getSource($file['media_sources_id']);
+        }
+
+        $file['categories']  = [];
+        $file['file_size']   = $this->formatFileSize($file['file_size']);
+        $file['file_path']   = $file['path'];
+        $file['is_archived'] = (int) $file['is_archived'];
+        $file['path']        = $this->fileUrl($file, $source);
+        $file['base_path']   = $source['basePath'];
+
+        if ($source['basePathRelative'] !== false) {
+            $file['base_path'] = $this->addTrailingSlash(MODX_BASE_PATH) .
+                $this->removeSlashes($source['basePath']) .
+                DIRECTORY_SEPARATOR;
+        }
+
+        return $file;
+    }
+
+    /**
      * Get files.
      *
      * @param string $search
@@ -697,25 +719,9 @@ class MediaManagerFilesHelper
         $source = null;
 
         foreach ($files as $file) {
-            $file = $file->toArray();
+            $file = $this->fileToArray($file);
 
-            if ($source === null) {
-                $source = $this->mediaManager->sources->getSource($file['media_sources_id']);
-            }
-
-            $file['categories'] = [];
-            $file['selected']   = 0;
-            $file['file_size']  = $this->formatFileSize($file['file_size']);
-            $file['file_path']  = $file['path'];
-            $file['path']       = $this->fileUrl($file, $source);
-            $file['base_path']  = $source['basePath'];
-
-            if ($source['basePathRelative'] !== false) {
-                $file['base_path'] = $this->addTrailingSlash(MODX_BASE_PATH) .
-                    $this->removeSlashes($source['basePath']) .
-                    DIRECTORY_SEPARATOR;
-            }
-
+            $file['selected'] = 0;
             if (in_array($file['id'], $selectedFilesIds)) {
                 $file['selected'] = 1;
             }

--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -1662,7 +1662,7 @@ class MediaManagerFilesHelper
             $old = $this->filePath($file->toArray());
             $new = $this->createUniqueFile($this->uploadDirectory . $this->archiveDirectory, time(), $file->get('file_type'), uniqid('-'));
 
-            if (!$this->renameFile($old, $this->uploadDirectory . $this->archiveDirectory . $new)) {
+            if (file_exists($old) && !$this->renameFile($old, $this->uploadDirectory . $this->archiveDirectory . $new)) {
                 $response['status'] = self::STATUS_ERROR;
                 $response['message'] .= $this->mediaManager->modx->lexicon('mediamanager.files.error.file_archive', array('id' => $id)) . '<br />';
                 continue;
@@ -1817,9 +1817,15 @@ class MediaManagerFilesHelper
             $old = $this->uploadDirectory . $file->get('archive_path');
             $new = $this->uploadDirectory . $file->get('path');
 
+            if (!file_exists($old)) {
+                $response['status'] = self::STATUS_ERROR;
+                $response['message'] .= $this->mediaManager->modx->lexicon('mediamanager.files.error.file_unarchive', array('id' => $id)) . '<br />';
+                continue;
+            }
+
             if (!$this->renameFile($old, $new)) {
                 $response['status'] = self::STATUS_ERROR;
-                $response['message'] .= $this->mediaManager->modx->lexicon('mediamanager.files.error.file_archive', array('id' => $id)) . '<br />';
+                $response['message'] .= $this->mediaManager->modx->lexicon('mediamanager.files.error.file_unarchive', array('id' => $id)) . '<br />';
                 continue;
             }
 

--- a/core/components/mediamanager/processors/mgr/thumbnail.class.php
+++ b/core/components/mediamanager/processors/mgr/thumbnail.class.php
@@ -24,7 +24,7 @@ class MediaManagerThumbnailProcessor extends modProcessor
             return '';
         }
 
-        if (!$this->modx->getService('phpthumb', 'modPhpThumb')) {
+        if (!$this->modx->getService('phpthumb', 'modPhpThumb', $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'model/phpthumb/')) {
             $this->modx->log(modX::LOG_LEVEL_ERROR,'Could not load modPhpThumb class.');
             return false;
         }


### PR DESCRIPTION
This PR fixes issue https://github.com/Sterc/mediamanager/issues/27

Changes:
1. Some refactoring (Add methods `getThumbnail` and `fileToArray`)
2. Add specifying of path to modPhpThumb in `getService` call
3. Check existence of file when archive and unarchive. We can archive if file not exists (for we can delete it next). But we can not unarchive if file not exists.
4. Delete versions and thumbnails when user delete main file.