### PR TITLE
Escape new reserved words for MySQL 8+

### DIFF
--- a/core/components/mediamanager/model/mediamanager/classes/categories.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/categories.class.php
@@ -269,7 +269,7 @@ class MediaManagerCategoriesHelper
             'media_sources_id' => $source
         ]);
         $q->sortby('parent_id', 'ASC');
-        $q->sortby('rank', 'ASC');
+        $q->sortby($this->mediaManager->modx->escape('rank'), 'ASC');
 
         return $this->mediaManager->modx->getCollection('MediamanagerCategories', $q);
     }


### PR DESCRIPTION
## What does it do

Escape some keywords now being reserved for MySQL 8+ (https://dev.mysql.com/doc/refman/8.0/en/keywords.html)

## Why is it needed?

Media Manager is broken when running on MySQL 8.0.2+

## How to test 

* install media manager in a setup with MySQL 8.0.2+
* confirm it's broken
* apply patch and confirm things are back on tracks

## Related issue(s)/PR(s)

none to our knowledge