### PR TITLE
Added new event when a file entry is saved (creation/update)

### DIFF
--- a/_build/resolvers/resolve.customevents.php
+++ b/_build/resolvers/resolve.customevents.php
@@ -10,6 +10,7 @@ if ($object->xpdo instanceof modX) {
     $events = [
         'MediaManagerFileArchived',
         'MediaManagerFileDeleted',
+        'MediaManagerFileSaved',
 
         'MediaManagerFileVersionChanged',
 

--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -1580,6 +1580,16 @@ class MediaManagerFilesHelper
         }
         $file->save();
 
+        $this->mediaManager->modx->invokeEvent(
+            'MediaManagerFileSaved',
+            [
+                'file_id' => $fileId,
+                'file' => $file,
+                'created_new_version' => $createFileVersion,
+                'version_number' => $file->get('version'),
+            ]
+        );
+
         return [];
     }
 


### PR DESCRIPTION
## What does it do

Creates a new `MediaManagerFileSaved` event fired whenever a file record is saved (either upon creation or update)

## Why is it needed

Some usage idea : 

* on file creation, generate a bunch of predefined image thumbnails
* on update, wipe resource cache where images known to be used