### PR TITLE
Fix issue with non existing users

### DIFF
--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -351,8 +351,10 @@ class MediaManagerFilesHelper
                 $versionArr['created_by'] != 0
             ) {
                 $user = $this->mediaManager->modx->getObject('modUser', ['id' => $versionArr['created_by']]);
-                $profile = $user->getOne('Profile');
-                $versionArr['created_by'] = $profile->get('fullname');
+                if ($user) {
+                    $profile = $user->getOne('Profile');
+                    $versionArr['created_by'] = $profile->get('fullname');
+                }
             }
 
             $fileInformation                = pathinfo($versionArr['path']);

--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -354,6 +354,8 @@ class MediaManagerFilesHelper
                 if ($user) {
                     $profile = $user->getOne('Profile');
                     $versionArr['created_by'] = $profile->get('fullname');
+                } else {
+                    $versionArr['created_by'] = $this->mediaManager->modx->lexicon('mediamanager.files.file_unknown_user');
                 }
             }
 


### PR DESCRIPTION
If a user doesn't exit you cant edit the mediafile, it gives an error.