### PR TITLE
Mediamanger AI 

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -4,6 +4,9 @@
     "description": "Media Manager for MODX.",
     "author": "Sterc",
     "version": "0.3.3",
+    "dependencies": {
+      "modAI": ">=0.13.1-pl"
+    },
     "package":{
         "menus": [{
             "text": "mediamanager",

--- a/assets/components/mediamanager/css/mgr/mediamanager.css
+++ b/assets/components/mediamanager/css/mgr/mediamanager.css
@@ -93,6 +93,20 @@
     margin: 0 0 10px;
 }
 
+.mediamanager-browser div.modal-body div.col-md-5 .dz-ai {
+    margin-bottom: 6px;
+    margin-top: 6px;
+}
+.mediamanager-browser div.modal.fade.in input ~ .dz-ai,
+.mediamanager-browser .dropzone-form .dz-preview .dz-ai {
+    margin-top: 6px;
+}
+
+.mediamanager-browser .dz-ai-reset,
+.mediamanager-browser .dz-ai-apply {
+    margin-right: 5px;
+}
+
 .mediamanager-browser .dropzone-form .dz-preview img {
     max-width: 80px;
     margin: 0 0 10px;

--- a/assets/components/mediamanager/js/mgr/mediamanager-files.js
+++ b/assets/components/mediamanager/js/mgr/mediamanager-files.js
@@ -54,6 +54,11 @@ $.fn.modal.Constructor.prototype.enforceFocus = function () {};
         $fileRevertButton        : 'button[data-revert-button]',
         $fileCrop                : 'img.crop',
         $filePreviewLink         : 'a[data-preview-link]',
+        $fileDzAIButton          : 'button[data-dz-call-ai]',
+        $fileEditAIButton        : 'button[data-edit-call-ai]',
+        $filePreviewAiButton     : 'button[data-preview-call-ai]',
+        $fileApplyAiButton       : 'button[data-apply-ai]',
+        $fileResetAiButton       : 'button[data-reset-ai]',
 
         $selectSource            : 'select[data-select-source]',
         $categoryTree            : 'div[data-category-tree]',
@@ -187,6 +192,108 @@ $.fn.modal.Constructor.prototype.enforceFocus = function () {};
                         var $fieldTags          = $(self.$fileTags, $file).select2(self.$filterTagsOptions);
                         var $fieldsMeta         = $(self.$fileMeta, $file);
                         var $fieldsLicense      = $(self.$fileLicense, $file);
+
+                        if (typeof modAI !== 'undefined' && modAI) {
+                            var $fileAIButton = $(self.$fileDzAIButton, $file);
+
+                            const fieldSchema = {}
+                            window.mediaManagerOptions.ai.forEach((item) => {
+                                fieldSchema[item.key] = item.prompt && item.prompt.trim() !== ''
+                                    ? 'string (' + item.prompt + ')'
+                                    : 'string';
+                            });
+
+                            const categoryPromt = `
+                            First, create your own descriptive categories freely based on the image content.
+                            Then, compare those freely created categories to the following predefined list, ignore the language and select all categories from the list that best match
+                            semantically, emotionally, or visually: ${self.$filterCategoriesOptions.data.map(item => item.text).join(',')}
+                            You may choose multiple matching categories from the list.
+                            If none of the freely created categories match the predefined list, use an empty array for “categories”.
+                            `;
+                            const tagPromt = `
+                            First, create your own descriptive tags freely based on the image content.
+                            Then, compare those freely created tags to the following predefined list, ignore the language and select all tags from the list that best match
+                            semantically, emotionally, or visually: ${self.$filterTagsOptions.data.map(item => item.text).join(',')}
+                            You may choose multiple matching tags from the list.
+                            If none of the freely created tags match the predefined list, use an empty array for “tags”.
+                            `;
+                            const AIPrompt = `Please analyze the following image.
+                            The output language must be in "${window.MODx.config.cultureKey}"
+                            Return the result as a JSON object with the following structure:
+    
+                            ${JSON.stringify(fieldSchema)}
+    
+                            ${tagPromt}
+    
+                            ${categoryPromt}
+    
+                            Ensure the output is valid JSON and matches the format exactly.
+                            Respond only with a single-line, compact, valid JSON object. Do not include code blocks, markdown, or any line breaks.
+                            The output must contain no \\n characters, no indentation, and no extra whitespace.`;
+
+                            $fileAIButton.on('click', async function (){
+                                const button = $(this).button('loading');
+                                try {
+                                    const img = $(file.previewElement).find('img').attr('src');
+                                    const result = await modAI.executor.mgr.prompt.vision(
+                                        {
+                                            image: img,
+                                            field: '',
+                                            prompt: AIPrompt,
+                                        }
+                                    )
+                                    const data = JSON.parse(result.content);
+                                    Object.entries(data).forEach(([key, value]) => {
+                                        let index = 0;
+                                        const $input = $(`[name="m[${key}]"]`, $file);
+                                        const inputField = $input[0];
+                                        function typeChar() {
+                                            const currentValue = (index === 0) ? '' : inputField.value;
+                                            if (index < value.length) {
+                                                inputField.value = currentValue + value.charAt(index);
+                                                index++;
+                                                inputField.scrollLeft = inputField.scrollWidth;
+                                                setTimeout(typeChar,30);
+                                            }
+                                        }
+                                        if (!['tags', 'categories'].includes(key)) {
+                                            typeChar();
+                                        }
+                                    })
+
+                                    function applySelectValues(sourceArray, targetArray, valueField, textField, $field) {
+                                        if (!Array.isArray(sourceArray) || sourceArray.length === 0) return;
+                                        if (!Array.isArray(targetArray) || targetArray.length === 0) return;
+
+                                        const matchedIds = targetArray
+                                            .filter(option => sourceArray.includes(option[textField]))
+                                            .map(option => option[valueField]);
+
+                                        $field.val(matchedIds).trigger('change');
+                                    }
+
+                                    applySelectValues(
+                                        data.tags,
+                                        self?.$filterTagsOptions?.data,
+                                        'id',
+                                        'text',
+                                        $fieldTags
+                                    );
+                                    applySelectValues(
+                                        data.categories,
+                                        self?.$filterCategoriesOptions?.data,
+                                        'id',
+                                        'text',
+                                        $fieldCategories
+                                    );
+                                } catch (e) {
+                                    console.error(e);
+                                } finally {
+                                    button.button('reset');
+                                }
+                            })
+                        }
+
 
                         if (data[$fieldCategories.attr('name')]) {
                             $fieldCategories.val(data[$fieldCategories.attr('name')]).trigger('change');

--- a/core/components/mediamanager/elements/plugins/mediamanagermodal.plugin.php
+++ b/core/components/mediamanager/elements/plugins/mediamanagermodal.plugin.php
@@ -15,5 +15,28 @@ switch ($modx->event->name) {
         $modx->regClientStartupScript($mediamanager->config['assets_url'] . 'libs/jquery-ui/1.11.4/js/jquery-ui.min.js');
         $modx->regClientStartupScript($mediamanager->config['assets_url'] . 'js/mgr/mediamanager-modal.js');
 
+        if (!$modx->services->has('modai')) {
+            return;
+        }
+        /** @var \modAI\modAI | null $modAI */
+        $modAI = $modx->services->get('modai');
+
+        if ($modAI === null) {
+            return;
+        }
+
+        $baseConfig = $modAI->getBaseConfig();
+        $modx->controller->addHtml(
+            <<<HTML
+                <script type="text/javascript">
+                let modAI;
+                Ext.onReady(function() {
+                    modAI = ModAI.init(' . json_encode($baseConfig) . ');
+                });
+                </script>
+            HTML
+        );
+
+        $modx->regClientStartupScript($modAI->getJSFile());
         break;
 }

--- a/core/components/mediamanager/lexicon/de/default.inc.php
+++ b/core/components/mediamanager/lexicon/de/default.inc.php
@@ -33,6 +33,7 @@ $_lang['mediamanager.global.use']               = 'Benutzen';
 $_lang['mediamanager.global.yes']               = 'Ja';
 $_lang['mediamanager.global.no']                = 'Nein';
 $_lang['mediamanager.global.error.mediasource'] = 'Ihr default mediasource (ID [[+ mediasource_id]]) ist nicht mit dem Media Manager konfiguriert. Bitte fügen Sie eine Property \'mediamanagerSource \' mit dem Wert \'1 \' zu diesem mediasource und alle anderen mediasources Sie mit dem Media Manager verwenden möchten.';
+$_lang['mediamanager.global.ai.button']         = 'Mit KI genrieren';
 
 /* Tags */
 $_lang['mediamanager.tags']                                     = 'Medien-Tags';
@@ -192,7 +193,10 @@ $_lang['mediamanager.files.source_valid_until']                 = 'Gültig bis [
 $_lang['mediamanager.files.license_file']                       = 'Hochladen der Lizenz- oder Zustimmungsdatei';
 $_lang['mediamanager.files.license_file_help']                  = 'Erlaubte Dateierweiterungen sind [[+extensions]].';
 $_lang['mediamanager.error.extension_not_allowed_for_field']    = 'Die Dateierweiterung ist für das Feld "[[+field]]" nicht zulässig. Erlaubte Dateierweiterungen sind [[+extensions]].';
-
+$_lang['mediamanager.files.ai.loading']                         = 'Generieren...';
+$_lang['mediamanager.files.ai.button']                          = $_lang['mediamanager.global.ai.button'];
+$_lang['mediamanager.files.ai.apply.button']                    = 'Anwenden';
+$_lang['mediamanager.files.ai.reset.button']                    = 'Zurücksetzen';
 /* Sources */
 $_lang['mediamanager.sources.root']                                         = 'None';
 
@@ -237,3 +241,6 @@ $_lang['mediamanager.license.email.message']                                = 'N
 $_lang['mediamanager.license.email.image_source_expired']                   = 'Bildquelle abgelaufen.';
 $_lang['mediamanager.license.email.image_about_to_expire_by_image_source']  = 'Das Bild läuft bald ab, basierend auf dem Ablaufdatum der Bildquelle.';
 $_lang['mediamanager.license.email.footer']                                 = 'Dies ist eine automatische Nachricht, die vom <strong>MediaManager</strong> von <strong>[[++site_name]]</strong> gesendet wird.';
+
+$_lang['mediamanager.ai.error.required_modai']                              = 'This Extra requires "modAI". Please install it first.';
+$_lang['mediamanager.ai.error.required_modai_version']                      = 'This Extra requires at least "modAI" version [[+version]].';

--- a/core/components/mediamanager/lexicon/en/default.inc.php
+++ b/core/components/mediamanager/lexicon/en/default.inc.php
@@ -33,6 +33,7 @@ $_lang['mediamanager.global.use']               = 'Use';
 $_lang['mediamanager.global.yes']               = 'Yes';
 $_lang['mediamanager.global.no']                = 'No';
 $_lang['mediamanager.global.error.mediasource'] = 'Your default mediasource (ID [[+mediasource_id]]) is not configured to use with the Media Manager. Please add a property \'mediamanagerSource\' with value \'1\' to this mediasource and all other mediasources you want to use with the Media Manager.';
+$_lang['mediamanager.global.ai.button']         = 'Generate with AI';
 
 /* Tags */
 $_lang['mediamanager.tags']                                 = 'Media Tags';
@@ -192,6 +193,9 @@ $_lang['mediamanager.files.source_valid_until']                 = 'Valid until [
 $_lang['mediamanager.files.license_file']                       = 'License or Consent file upload';
 $_lang['mediamanager.files.license_file_help']                  = 'Allowed file extensions are [[+extensions]].';
 $_lang['mediamanager.error.extension_not_allowed_for_field']    = 'File extension is not allowed for field "[[+field]]". Allowed file extensions are [[+extensions]].';
+$_lang['mediamanager.files.ai.button']                          = $_lang['mediamanager.global.ai.button'];
+$_lang['mediamanager.files.ai.apply.button']                    = 'Apply';
+$_lang['mediamanager.files.ai.reset.button']                    = 'Reset';
 
 /* Sources */
 $_lang['mediamanager.sources.root']                                         = 'None';
@@ -237,3 +241,6 @@ $_lang['mediamanager.license.email.message']                                = 'M
 $_lang['mediamanager.license.email.image_source_expired']                   = 'Image source expired.';
 $_lang['mediamanager.license.email.image_about_to_expire_by_image_source']  = 'Image is about to expire based on the image source expiry date.';
 $_lang['mediamanager.license.email.footer']                                 = 'This is an automated message sent by the <strong>MediaManager</strong> from <strong>[[++site_name]]</strong>.';
+
+$_lang['mediamanager.ai.error.required_modai']                              = 'This Extra requires "modAI". Please install it first.';
+$_lang['mediamanager.ai.error.required_modai_version']                      = 'This Extra requires at least "modAI" version [[+version]].';

--- a/core/components/mediamanager/model/mediamanager/classes/sources.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/sources.class.php
@@ -234,6 +234,8 @@ class MediaManagerSourcesHelper
             }
         }
 
+        $output[] = '<script> window.mediaManagerOptions.ai = ' . json_encode($source['meta']) . '</script>';
+
         return implode(PHP_EOL, $output);
     }
 

--- a/core/components/mediamanager/templates/chunks/files/dropzone_file.chunk.tpl
+++ b/core/components/mediamanager/templates/chunks/files/dropzone_file.chunk.tpl
@@ -32,6 +32,8 @@
             <div class="col-sm-1">
                 <p>
                     <button type="button" class="btn btn-danger dz-remove pull-right" data-dz-remove="">[[%mediamanager.global.delete]]</button>
+                    <button type="button" class="btn btn-primary dz-ai pull-right"
+                            data-dz-call-ai data-loading-text="[[%mediamanager.files.ai.loading]]">[[%mediamanager.files.ai.button]]</button>
                 </p>
             </div>
         </div>

--- a/core/components/mediamanager/templates/chunks/files/formgroup_filemeta.chunk.tpl
+++ b/core/components/mediamanager/templates/chunks/files/formgroup_filemeta.chunk.tpl
@@ -11,6 +11,14 @@
         <div class="col-md-6">
             <input type="text" class="form-control" name="meta[ [[+prefix]] ][value]" placeholder="[[%mediamanager.files.meta.value]]" value="[[+meta_value]]" />
         </div>
+        <button type="button" class="btn btn-primary dz-ai pull-right"
+                data-edit-call-ai="[[+meta_key]]" data-loading-text="[[%mediamanager.files.ai.loading]]">
+            [[%mediamanager.files.ai.button]]
+        </button>
+        <button type="button" class="btn btn-success dz-ai dz-ai-apply pull-right hidden"
+                data-apply-ai="[[+meta_key]]">[[%mediamanager.files.ai.apply.button]]</button>
+        <button type="button" class="btn btn-danger dz-ai dz-ai-reset pull-right hidden"
+                data-reset-ai="[[+meta_key]]">[[%mediamanager.files.ai.reset.button]]</button>
         <div class="col-md-1">
             [[+disabled:eq=`1`:then=`
 

--- a/core/components/mediamanager/templates/chunks/files/popup/preview.chunk.tpl
+++ b/core/components/mediamanager/templates/chunks/files/popup/preview.chunk.tpl
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-md-5">
+    <div class="col-md-5 clearfix">
 
         <div class="file-preview">
             [[+preview]]
@@ -10,10 +10,24 @@
             [[+categories]]
         </select>
 
+        <button type="button" class="btn btn-primary dz-ai pull-right"
+                data-preview-call-ai="categories" data-loading-text="[[%mediamanager.files.ai.loading]]">[[%mediamanager.files.ai.button]]</button>
+        <button type="button" class="btn btn-success dz-ai dz-ai-apply pull-right hidden"
+                data-apply-ai="categories">[[%mediamanager.files.ai.apply.button]]</button>
+        <button type="button" class="btn btn-danger dz-ai dz-ai-reset pull-right hidden"
+                data-reset-ai="categories">[[%mediamanager.files.ai.reset.button]]</button>
+
         <label class="spacing">[[%mediamanager.global.tags]]</label>
         <select name="tags[]" class="form-control" multiple="multiple" data-placeholder="[[%mediamanager.global.tags]]" data-file-tags [[+can_edit:is=`0`:then=` disabled`]]>
             [[+tags]]
         </select>
+
+        <button type="button" class="btn btn-primary dz-ai pull-right"
+                data-preview-call-ai="tags" data-loading-text="[[%mediamanager.files.ai.loading]]">[[%mediamanager.files.ai.button]]</button>
+        <button type="button" class="btn btn-success dz-ai dz-ai-apply pull-right hidden"
+                data-apply-ai="tags">[[%mediamanager.files.ai.apply.button]]</button>
+        <button type="button" class="btn btn-danger dz-ai dz-ai-reset pull-right hidden"
+                data-reset-ai="tags">[[%mediamanager.files.ai.reset.button]]</button>
 
         [[-<label class="spacing">[[%mediamanager.files.source_tags]]</label>
         <select name="source_tags[]" class="form-control" multiple="multiple" data-placeholder="[[%mediamanager.files.source_tags]]" data-file-source-tags [[+can_edit:is=`0`:then=` disabled`]]>


### PR DESCRIPTION
Overall, this commit adds AI integration capabilities to the Media Manager, allowing users to process media metadata using AI algorithms directly from within the manager interface.

1. Modified sources.class.php to include AI-related meta data when rendering source configurations.

2. Added support for calling AI from media manager modal plugin:
   - Checks if modAI service is available
   - Initializes modAI instance with base config
   - Registers modAI JavaScript file

3. Updated formgroup_filemeta.chunk.tpl to add buttons for calling AI on specific metadata fields:
   - "Call AI" button that triggers AI processing
   - "Apply" and "Reset" buttons for applying/reverting AI changes (hidden initially)

4. Modified dropzone_file.chunk.tpl to include an "AI" button for each file, which calls AI processing.

5. Updated the Media Manager template files to use new classes and data attributes for AI functionality.

6. Added translations for new AI-related strings in language files.

