### PR TITLE
Only save new version id if a new fileversion was created

### DIFF
--- a/core/components/mediamanager/model/mediamanager/classes/files.class.php
+++ b/core/components/mediamanager/model/mediamanager/classes/files.class.php
@@ -1477,6 +1477,9 @@ class MediaManagerFilesHelper
         // Check whether or not a file version should be created.
         $createFileVersion = false;
         $actionName        = '';
+
+        // sanitize early before change-check
+        $data['name'] = $this->sanitizeFileName($data['name']);
         if ($file->get('name') !== $data['name']) {
             $createFileVersion = true;
             $actionName        = 'rename';
@@ -1490,11 +1493,7 @@ class MediaManagerFilesHelper
             ];
         }
 
-        $version                = $this->createVersionNumber($file->get('id'));
-        $data['version']        = $version;
-
         $file->set('name',      $this->sanitizeFileName($data['name']));
-        $file->set('version',   $data['version']);
         $file->set('edited_on', time());
         $file->set('edited_by', $this->mediaManager->modx->getUser()->get('id'));
 
@@ -1576,6 +1575,8 @@ class MediaManagerFilesHelper
         }
 
         if ($createFileVersion) {
+            $data['version'] = $this->createVersionNumber($file->get('id'));
+            $file->set('version', $data['version']);
             $this->saveFileVersion($file->get('id'), $data, $actionName);
         }
         $file->save();


### PR DESCRIPTION
# Bug description
Found a bug when editing an existing image **for the first time** and changing metadata of the image (not the name, but e.g. alt-text).

If the `modx_mediamanager_files` table showed `version` = `1` before for that file, during that metadata save the `version` is updated to `2`, but no actual new `MediamanagerFilesVersions` object is created (because just metadata was updated).

The version is than stuck at value `2`, because the highest version number found is still `1` which is incremented to `2` again at subsequent metadata updates.

This PR fixes this by only incrementing (creating a new) version number when an actual version object is created.